### PR TITLE
Adding support for async using a feature as a toggle. Based heavily o…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,16 @@ documentation = "https://docs.rs/sht4x"
 repository = "https://github.com/sirhcel/sht4x"
 readme = "README.md"
 
-exclude = [
-    "/.github/",
-    ".gitignore",
-]
+exclude = ["/.github/", ".gitignore"]
 
 
 [dependencies]
 defmt = { version = "0.3.2", optional = true }
 embedded-hal = "1.0.0"
+embedded-hal-async = { version = "1.0.0", optional = true }
 fixed = "1.20.0"
 sensirion-i2c = "0.3.0"
 
 [features]
 defmt = ["dep:defmt"]
+async = ["dep:embedded-hal-async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sht4x"
 description = "Sensirion SHT4x Driver for Embedded HAL"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 authors = ["Christian Meusel <christian.meusel@posteo.de>"]

--- a/README.md
+++ b/README.md
@@ -13,30 +13,30 @@ tested with the SHT40-AD1B so far.
 [![crates.io](https://img.shields.io/crates/v/sht4x.svg)](https://crates.io/crates/sht4x)
 ![Documentation](https://docs.rs/sht4x/badge.svg)
 
-
 ## Features
 
 - Blocking operation
+- Async operation if the `async` feature is specified
+- Uses the latest embedded_hal 1.0.0
 - Supports all commands specified in the
   [datasheet](https://sensirion.com/media/documents/33FD6951/624C4357/Datasheet_SHT4x.pdf)
-- Explicitly borrows `DelayMs` for command execution so that it could be shared
+- Explicitly borrows `DelayNs` for command execution so that it could be shared
   (among multiple sensors)
 - Could be instantiated with the alternative I2C address for the SHT40-BD1B
 - Uses fixed-point arithmetics for converting raw sensor data into measurements
   in SI units
-    - Based on `I16F16` from the [`fixed`](https://gitlab.com/tspiteri/fixed)
-      crate
-    - Allows conversion to floating-point values, if needed
-    - Convenience methods for fixed-point conversions to milli degree Celsius
-      or milli percent relative humidity which are commonly used by drivers for
-      other humidity and temperature sensors from Sensirion
+  - Based on `I16F16` from the [`fixed`](https://gitlab.com/tspiteri/fixed)
+    crate
+  - Allows conversion to floating-point values, if needed
+  - Convenience methods for fixed-point conversions to milli degree Celsius
+    or milli percent relative humidity which are commonly used by drivers for
+    other humidity and temperature sensors from Sensirion
 - Optional support for [`defmt`](https://github.com/knurling-rs/defmt)
-
 
 ## Example
 
 ```rust ignore
-use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::delay::DelayNs;
 use sht4x::Sht4x;
 // Device-specific use declarations.
 
@@ -59,12 +59,10 @@ if let Ok(measurement) = measurement {
 }
 ```
 
-
 ## Related Work
 
 [sensor-temp-humidity-sht40](https://github.com/lc525/sensor-temp-humidity-sht40-rs)
 is another driver for this sensor family.
-
 
 ## License
 
@@ -77,7 +75,6 @@ Licensed under either of
   <http://opensource.org/licenses/MIT>)
 
 at your discretion.
-
 
 ### Contribution
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use embedded_hal::i2c::I2c;
-use sensirion_i2c::i2c;
+use sensirion_i2c;
 
 /// Error conditions from accessing SHT4x sensors.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -12,12 +12,21 @@ pub enum Error<E> {
     Crc,
 }
 
-impl<I: I2c> From<i2c::Error<I>> for Error<I::Error> {
-    fn from(err: i2c::Error<I>) -> Self {
+impl<I: I2c> From<sensirion_i2c::i2c::Error<I>> for Error<I::Error> {
+    fn from(err: sensirion_i2c::i2c::Error<I>) -> Self {
         match err {
-            i2c::Error::Crc => Error::Crc,
-            i2c::Error::I2cRead(e) => Error::I2c(e),
-            i2c::Error::I2cWrite(e) => Error::I2c(e),
+            sensirion_i2c::i2c::Error::Crc => Error::Crc,
+            sensirion_i2c::i2c::Error::I2cRead(e) => Error::I2c(e),
+            sensirion_i2c::i2c::Error::I2cWrite(e) => Error::I2c(e),
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<E> From<sensirion_i2c::crc8::Error> for Error<E> {
+    fn from(value: sensirion_i2c::crc8::Error) -> Self {
+        match value {
+            sensirion_i2c::crc8::Error::CrcError => Error::Crc,
         }
     }
 }

--- a/src/sht4x.rs
+++ b/src/sht4x.rs
@@ -4,9 +4,14 @@ use crate::{
     types::{Address, HeatingDuration, HeatingPower, Measurement, Precision, SensorData},
 };
 use core::marker::PhantomData;
+
+use sensirion_i2c;
+
+#[cfg(not(feature = "async"))]
 use embedded_hal::{delay::DelayNs, i2c::I2c};
 
-use sensirion_i2c::i2c;
+#[cfg(feature = "async")]
+use embedded_hal_async::{delay::DelayNs, i2c::I2c};
 
 const RESPONSE_LEN: usize = 6;
 
@@ -75,6 +80,7 @@ where
         self.i2c
     }
 
+    #[cfg(not(feature = "async"))]
     /// Activates the heater and performs a measurement returning measurands in SI units.
     ///
     /// **Note:** The heater is designed to be used up to 10 % of the sensor's lifetime. Please
@@ -92,6 +98,25 @@ where
         Ok(Measurement::from(raw))
     }
 
+    #[cfg(feature = "async")]
+    /// Activates the heater and performs a measurement returning measurands in SI units.
+    ///
+    /// **Note:** The heater is designed to be used up to 10 % of the sensor's lifetime. Please
+    /// check the
+    /// [datasheet](https://sensirion.com/media/documents/33FD6951/624C4357/Datasheet_SHT4x.pdf),
+    /// section 4.9 _Heater Operation_ for details.
+    pub async fn heat_and_measure(
+        &mut self,
+        power: HeatingPower,
+        duration: HeatingDuration,
+        delay: &mut D,
+    ) -> Result<Measurement, Error<I::Error>> {
+        let raw = self.heat_and_measure_raw(power, duration, delay).await?;
+
+        Ok(Measurement::from(raw))
+    }
+
+    #[cfg(not(feature = "async"))]
     /// Activates the heater and performs a measurement returning raw sensor data.
     ///
     /// **Note:** The heater is designed to be used up to 10 % of the sensor's lifetime. Please
@@ -113,6 +138,30 @@ where
         Ok(raw)
     }
 
+    #[cfg(feature = "async")]
+    /// Activates the heater and performs a measurement returning raw sensor data.
+    ///
+    /// **Note:** The heater is designed to be used up to 10 % of the sensor's lifetime. Please
+    /// check the
+    /// [datasheet](https://sensirion.com/media/documents/33FD6951/624C4357/Datasheet_SHT4x.pdf),
+    /// section 4.9 _Heater Operation_ for details.
+    pub async fn heat_and_measure_raw(
+        &mut self,
+        power: HeatingPower,
+        duration: HeatingDuration,
+        delay: &mut D,
+    ) -> Result<SensorData, Error<I::Error>> {
+        let command = Command::from((power, duration));
+
+        self.write_command_and_delay_for_execution(command, delay)
+            .await?;
+        let response = self.read_response().await?;
+        let raw = self.sensor_data_from_response(&response);
+
+        Ok(raw)
+    }
+
+    #[cfg(not(feature = "async"))]
     /// Performs a measurement returning measurands in SI units.
     pub fn measure(
         &mut self,
@@ -123,6 +172,18 @@ where
         Ok(Measurement::from(raw))
     }
 
+    #[cfg(feature = "async")]
+    /// Performs a measurement returning measurands in SI units.
+    pub async fn measure(
+        &mut self,
+        precision: Precision,
+        delay: &mut D,
+    ) -> Result<Measurement, Error<I::Error>> {
+        let raw = self.measure_raw(precision, delay).await?;
+        Ok(Measurement::from(raw))
+    }
+
+    #[cfg(not(feature = "async"))]
     /// Performs a measurement returning raw sensor data.
     pub fn measure_raw(
         &mut self,
@@ -138,6 +199,24 @@ where
         Ok(raw)
     }
 
+    #[cfg(feature = "async")]
+    /// Performs a measurement returning raw sensor data.
+    pub async fn measure_raw(
+        &mut self,
+        precision: Precision,
+        delay: &mut D,
+    ) -> Result<SensorData, Error<I::Error>> {
+        let command = Command::from(precision);
+
+        self.write_command_and_delay_for_execution(command, delay)
+            .await?;
+        let response = self.read_response().await?;
+        let raw = self.sensor_data_from_response(&response);
+
+        Ok(raw)
+    }
+
+    #[cfg(not(feature = "async"))]
     /// Reads the sensor's serial number.
     pub fn serial_number(&mut self, delay: &mut D) -> Result<u32, Error<I::Error>> {
         self.write_command_and_delay_for_execution(Command::SerialNumber, delay)?;
@@ -151,15 +230,53 @@ where
         ]))
     }
 
+    #[cfg(feature = "async")]
+    /// Reads the sensor's serial number.
+    pub async fn serial_number(&mut self, delay: &mut D) -> Result<u32, Error<I::Error>> {
+        self.write_command_and_delay_for_execution(Command::SerialNumber, delay)
+            .await?;
+        let response = self.read_response().await?;
+
+        Ok(u32::from_be_bytes([
+            response[0],
+            response[1],
+            response[3],
+            response[4],
+        ]))
+    }
+
+    #[cfg(not(feature = "async"))]
     /// Performs a soft reset of the sensor.
     pub fn soft_reset(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
         self.write_command_and_delay_for_execution(Command::SoftReset, delay)
     }
 
+    #[cfg(feature = "async")]
+    /// Performs a soft reset of the sensor.
+    pub async fn soft_reset(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
+        self.write_command_and_delay_for_execution(Command::SoftReset, delay)
+            .await
+    }
+
+    #[cfg(not(feature = "async"))]
     fn read_response(&mut self) -> Result<[u8; RESPONSE_LEN], Error<I::Error>> {
         let mut response = [0; RESPONSE_LEN];
 
-        i2c::read_words_with_crc(&mut self.i2c, self.address.into(), &mut response)?;
+        sensirion_i2c::i2c::read_words_with_crc(&mut self.i2c, self.address.into(), &mut response)?;
+
+        Ok(response)
+    }
+
+    #[cfg(feature = "async")]
+    async fn read_response(&mut self) -> Result<[u8; RESPONSE_LEN], Error<I::Error>> {
+        let mut response = [0; RESPONSE_LEN];
+
+        self.i2c
+            .read(self.address.into(), &mut response)
+            .await
+            .map_err(Error::I2c)?;
+
+        sensirion_i2c::crc8::validate(&response)?;
 
         Ok(response)
     }
@@ -171,6 +288,7 @@ where
         }
     }
 
+    #[cfg(not(feature = "async"))]
     fn write_command_and_delay_for_execution(
         &mut self,
         command: Command,
@@ -178,8 +296,27 @@ where
     ) -> Result<(), Error<I::Error>> {
         let code = command.code();
 
-        i2c::write_command_u8(&mut self.i2c, self.address.into(), code).map_err(Error::I2c)?;
+        sensirion_i2c::i2c::write_command_u8(&mut self.i2c, self.address.into(), code)
+            .map_err(Error::I2c)?;
         delay.delay_ms(command.duration_ms());
+
+        Ok(())
+    }
+
+    #[cfg(feature = "async")]
+    async fn write_command_and_delay_for_execution(
+        &mut self,
+        command: Command,
+        delay: &mut D,
+    ) -> Result<(), Error<I::Error>> {
+        let code = command.code();
+
+        self.i2c
+            .write(self.address.into(), &code.to_be_bytes())
+            .await
+            .map_err(Error::I2c)?;
+
+        delay.delay_ms(command.duration_ms()).await;
 
         Ok(())
     }


### PR DESCRIPTION
Added async support. This is based upon the work of @tazz4843. The reason I did not use his branch is that I wanted this to be based on your changes to use embedded-hal-1.0.0.

With embedded-hal-1.0.0 this allowed for putting all the methods in the same impl block and then feature gating them. I also chose to just add one feature, `async`, that effectively works as a toggle vs adding a `blocking` and an `async` feature as was done in the branch by @tazz4843. Since now both synchronous and asynchronous are using embedded-hal-1.0.0, there was no need to have two separate impl as the signature is now the same.

I'm not sure if you're going to want to pull it in here, since it is out of the scope of your pull request to https://github.com/sirhcel/sht4x. So I can always try to get this pulled in later to his branch after he pulls yours in.